### PR TITLE
bug PIZ-1: User can't create an order

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,11 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+
+@size.route('/', methods=GET)
+def get_sizes():
+    size, error = SizeController.get_all()
+    response = size if not error else {'error': error}
+    status_code = 200 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
#### 🤔 Why?

- User wasn't able to create an order. 

#### 🛠 What I changed:

- I created the `get_sizes` endpoint in the `app/services/size.py`

#### 🗃️ Jira Issues:

- [PIZ-1](https://trello.com/c/4RsOmRi1/1-piz1-i-cant-create-an-order-bug)

#### 🚦 Functional Testing Results:

- Before:
![image](https://user-images.githubusercontent.com/38624839/191130380-80cc4c4c-c207-4997-970d-bf095ee768f0.png)
![image](https://user-images.githubusercontent.com/38624839/191130438-14ed0882-6a78-436e-875e-a8ff4d97abc7.png)

- After:
![image](https://user-images.githubusercontent.com/38624839/191130193-94510293-80a5-4615-898c-55f5fc73fdbe.png)
![image](https://user-images.githubusercontent.com/38624839/191130273-c386cc74-b5c5-47de-b67e-cb82f7653995.png)
