### PR TITLE
PIZ-7: fixing total price calculation

### DIFF
--- a/app/controllers/order.py
+++ b/app/controllers/order.py
@@ -12,7 +12,7 @@ class OrderController(BaseController):
 
     @staticmethod
     def calculate_order_price(size_price: float, ingredients: list):
-        price = sum(ingredient.price for ingredient in ingredients)
+        price = sum(ingredient.price for ingredient in ingredients) + size_price
         return round(price, 2)
 
     @classmethod


### PR DESCRIPTION
#### 🤔 Why?

- Order's total price wasn't counting the size price

#### 🛠 What I changed:

- I added the `size_price` in the sum of the total price. `app/controllers/order.py`

#### 🗃️ Jira Issues:

- [PIZ-7](https://trello.com/c/vPMot5IH/9-piz7-fix-order-price-calculation-bonus)

#### 🚦 Functional Testing Results:

- **Tests**:
    - Before: 
![image](https://user-images.githubusercontent.com/38624839/191131986-f9fefcca-6a98-406b-84e9-a1c5f3322281.png)

    - After:
![image](https://user-images.githubusercontent.com/38624839/191131714-336b42a9-4df0-4123-92ad-18de38ca0030.png)

- **UI**:
    - Before:
![image](https://user-images.githubusercontent.com/38624839/191131908-95665223-6174-48aa-b9a4-b4198682c817.png)

    - After:
![image](https://user-images.githubusercontent.com/38624839/191131825-61f6c4f5-bb3f-4de6-a79e-19c5c4d581c7.png)
